### PR TITLE
added ability to override default environmental variables for minio connection

### DIFF
--- a/R/get_object.R
+++ b/R/get_object.R
@@ -83,6 +83,10 @@ function(object,
          file = basename(object),
          overwrite = TRUE,
          use_https,
+         base_url,
+         region,
+         key,
+         secret,
          ...) {
     if (missing(bucket)) {
         bucket <- get_bucketname(object)

--- a/R/get_object.R
+++ b/R/get_object.R
@@ -87,6 +87,25 @@ function(object,
     if (missing(bucket)) {
         bucket <- get_bucketname(object)
     } 
+    
+    if (missing(base_url)) {
+        base_url = Sys.getenv("AWS_S3_ENDPOINT")
+    } 
+    
+    
+    if (missing(region)) {
+        region = Sys.getenv("AWS_DEFAULT_REGION")
+    } 
+    
+    if (missing(key)) {
+        key = Sys.getenv("AWS_ACCESS_KEY_ID")
+    } 
+    
+    if (missing(secret)) {
+        secret = Sys.getenv("AWS_SECRET_ACCESS_KEY")
+    } 
+    
+    
     object <- get_objectkey(object)
     
     # create dir() if missing
@@ -107,11 +126,11 @@ function(object,
                 parse_response = TRUE, 
                 check_region = FALSE,
                 url_style = c("path", "virtual"),
-                base_url = Sys.getenv("AWS_S3_ENDPOINT"),
+                base_url = base_url,
                 verbose = getOption("verbose", FALSE),
-                region = Sys.getenv("AWS_DEFAULT_REGION"), 
-                key = Sys.getenv("AWS_ACCESS_KEY_ID"), 
-                secret = Sys.getenv("AWS_SECRET_ACCESS_KEY"), 
+                region = region, 
+                key = key, 
+                secret = secret, 
                 session_token = NULL,
                 use_https = use_https)
     return(file)

--- a/R/put_object.R
+++ b/R/put_object.R
@@ -68,6 +68,26 @@ function(file,
         }
         object <- get_objectkey(object)
     }
+         
+    if (missing(base_url)) {
+        base_url = Sys.getenv("AWS_S3_ENDPOINT")
+    } 
+
+
+    if (missing(region)) {
+        region = Sys.getenv("AWS_DEFAULT_REGION")
+    } 
+
+    if (missing(key)) {
+        key = Sys.getenv("AWS_ACCESS_KEY_ID")
+    } 
+
+    if (missing(secret)) {
+        secret = Sys.getenv("AWS_SECRET_ACCESS_KEY")
+    }      
+         
+         
+         
     acl <- match.arg(acl)
     headers <- c(list(`x-amz-acl` = acl), headers)
     if (isTRUE(multipart)) {
@@ -136,11 +156,11 @@ function(file,
                     parse_response = TRUE, 
                     check_region = FALSE,
                     url_style = c("path", "virtual"),
-                    base_url = Sys.getenv("AWS_S3_ENDPOINT"),
+                    base_url = base_url,
                     verbose = getOption("verbose", FALSE),
-                    region = Sys.getenv("AWS_DEFAULT_REGION"), 
-                    key = Sys.getenv("AWS_ACCESS_KEY_ID"), 
-                    secret = Sys.getenv("AWS_SECRET_ACCESS_KEY"), 
+                    region = region, 
+                    key = key, 
+                    secret = secret, 
                     session_token = NULL,
                     use_https = FALSE)
         return(TRUE)
@@ -179,11 +199,11 @@ post_object <- function(file, object, bucket, headers = list(), ...) {
                 parse_response = TRUE, 
                 check_region = FALSE,
                 url_style = c("path", "virtual"),
-                base_url = Sys.getenv("AWS_S3_ENDPOINT"),
+                base_url = base_url,
                 verbose = getOption("verbose", FALSE),
-                region = Sys.getenv("AWS_DEFAULT_REGION"), 
-                key = Sys.getenv("AWS_ACCESS_KEY_ID"), 
-                secret = Sys.getenv("AWS_SECRET_ACCESS_KEY"), 
+                region = region, 
+                key = key, 
+                secret = secret, 
                 session_token = NULL,
                 use_https = FALSE)
     structure(r, class = "s3_object")


### PR DESCRIPTION
Before we could not specify a custom base_url, region, key, and secret to connect to more than one minio instances at a time